### PR TITLE
[BrokenLinksH2] -- update Walkthrough/Quickstart link targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,4 @@ This repository contains samples for building apps with tabs in ASP.NET Core on 
 Copyright (c) 2017 Microsoft Corporation. All rights reserved.
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information, see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+ 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ This repository contains samples for building apps with tabs in ASP.NET Core on 
 
 | Sample Name | Technology | Instructions |
 |-------------|------------|--------------|
-| Channel and group tabs | ASP.NET Core + Razor | [Walkthrough](https://docs.microsoft.com/microsoftteams/platform/tabs/quickstarts/create-channel-group-tab-dotnet-core) |
-| Channel and group tabs | ASP.NET Core + MVC | [Walkthrough](https://docs.microsoft.com/microsoftteams/platform/tabs/quickstarts/create-channel-group-tab-dotnet-core-mvc) |
-| Personal tabs | ASP.NET Core + Razor | [Walkthrough](https://docs.microsoft.com/microsoftteams/platform/tabs/quickstarts/create-personal-tab-dotnet-core) |
-| Personal tabs | ASP.NET Core + MVC | [Walkthrough](https://docs.microsoft.com/microsoftteams/platform/tabs/quickstarts/create-personal-tab-dotnet-core-mvc) |
+| Channel and group tabs | ASP.NET Core + Razor | [Quickstart](https://docs.microsoft.com/samples/officedev/microsoft-teams-samples/channel-and-group-tabs-in-aspnet-core-with-razor-pages/) |
+| Channel and group tabs | ASP.NET Core + MVC | [Quickstart](https://docs.microsoft.com/samples/officedev/microsoft-teams-samples/channel-and-group-tabs-in-aspnet-core-with-mvc/) |
+| Personal tabs | ASP.NET Core + Razor | [Quickstart](https://docs.microsoft.com/samples/officedev/microsoft-teams-samples/personal-tab-with-aspnet-core/) |
+| Personal tabs | ASP.NET Core + MVC | [Quickstart](https://docs.microsoft.com/samples/officedev/microsoft-teams-samples/personal-tab-with-asp-net-core-mvc/) |
 
 ## Copyright
 Copyright (c) 2017 Microsoft Corporation. All rights reserved.

--- a/README.md
+++ b/README.md
@@ -29,4 +29,3 @@ This repository contains samples for building apps with tabs in ASP.NET Core on 
 Copyright (c) 2017 Microsoft Corporation. All rights reserved.
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information, see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
- 


### PR DESCRIPTION
**Global effort to fix broken links** 

@ydogandjiev, @richardtaylorrt, @davidchesnut

The Content & Learning team is fixing broken links on docs.microsoft.com for the rest of H2. This effort will eliminate potential accessibility, security, and usability issues. This PR includes only link fixes and does not change other content. I’d very much appreciate your timely review and feedback on the link changes I’ve suggested. Thanks!


